### PR TITLE
Improving how annotations with multi-line bodies are handled.

### DIFF
--- a/.idea/runConfigurations/_template__of_Dart_Test.xml
+++ b/.idea/runConfigurations/_template__of_Dart_Test.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="true" type="DartTestRunConfigurationType" factoryName="Dart Test">
+    <option name="VMOptions" value="--no-sound-null-safety" />
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/_template__of_Dart_Test4.xml
+++ b/.idea/runConfigurations/_template__of_Dart_Test4.xml
@@ -1,6 +1,5 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="true" type="DartTestRunConfigurationType" factoryName="Dart Test">
-    <option name="VMOptions" value="--no-sound-null-safety" />
     <method v="2" />
   </configuration>
 </component>

--- a/js/apex-reflection-node/package.json
+++ b/js/apex-reflection-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cparra/apex-reflection",
-  "version": "2.9.5",
+  "version": "2.10.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/lib/src/extension_methods/list_extensions.dart
+++ b/lib/src/extension_methods/list_extensions.dart
@@ -19,3 +19,9 @@ extension FirstWhereOrNullExtension<E> on Iterable<E> {
     return null;
   }
 }
+
+extension ReversedIterable<E> on Iterable<E> {
+  Iterable<E> get reversed {
+    return toList().reversed;
+  }
+}

--- a/lib/src/model/doc_comment.dart
+++ b/lib/src/model/doc_comment.dart
@@ -35,11 +35,16 @@ class DocComment {
 
   Map<String, dynamic> toJson() => _$DocCommentToJson(this);
 
-  List<String> get descriptionLines => _descriptionLines.isNotEmpty
-      ? _descriptionLines
-      : annotations
-          .firstWhereOrNull((element) => element.name == 'description')
-          ?.bodyLines ?? [];
+  List<String> get descriptionLines {
+    print('getting description lines ${_descriptionLines.length}');
+    print('with annotations ${annotations.map((e) => e.toJson())}');
+    return _descriptionLines.isNotEmpty
+        ? _descriptionLines
+        : annotations
+                .firstWhereOrNull((element) => element.name == 'description')
+                ?.bodyLines ??
+            [];
+  }
 
   set descriptionLines(List<String> descriptionLines) {
     List<String> cleanLines = [];
@@ -51,16 +56,33 @@ class DocComment {
           trimmedLine = '';
         }
 
-        if (trimmedLine.isNotEmpty) {
-          cleanLines.add(trimmedLine);
-        }
+        cleanLines.add(trimmedLine);
       }
     }
+
+    // If the first line is empty, remove it
+    if (cleanLines.isNotEmpty && cleanLines.first.isEmpty) {
+      cleanLines.removeAt(0);
+    }
+    // If the last line is empty, remove it
+    if (cleanLines.isNotEmpty && cleanLines.last.isEmpty) {
+      cleanLines.removeLast();
+    }
+
+    // When there are 2 blank strings back to back, remove one of them
+    for (int i = 0; i < cleanLines.length - 1; i++) {
+      if (cleanLines[i].isEmpty && cleanLines[i + 1].isEmpty) {
+        cleanLines.removeAt(i);
+      }
+    }
+
     _descriptionLines = cleanLines;
   }
 
   /// Gets the description as a single line.
-  String get description => descriptionLines.join(' ');
+  String get description => descriptionLines
+      .map((e) => e == '' ? '\n' : e)
+      .join('');
 
   List<DocCommentAnnotation> annotationsByName(String annotationName) {
     return annotations
@@ -77,7 +99,7 @@ class DocCommentAnnotation {
 
   List<String> bodyLines = [];
 
-  String get body => bodyLines.join(' ');
+  String get body => bodyLines.map((e) => e.isEmpty ? '\n' : e).join('');
 
   DocCommentAnnotation(this.name, body) {
     if (body is String) {

--- a/lib/src/model/doc_comment.dart
+++ b/lib/src/model/doc_comment.dart
@@ -1,4 +1,5 @@
 import 'package:apexdocs_dart/src/extension_methods/list_extensions.dart';
+import 'package:apexdocs_dart/src/model/multi_line_apex_doc_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'doc_comment.g.dart';
@@ -43,36 +44,8 @@ class DocComment {
           [];
 
   set descriptionLines(List<String> descriptionLines) {
-    List<String> cleanLines = [];
-    for (String currentLine in descriptionLines) {
-      List<String> splitLines = currentLine.split('\n');
-      for (String splitLine in splitLines) {
-        String trimmedLine = splitLine.trim();
-        if (trimmedLine == '*') {
-          trimmedLine = '';
-        }
-
-        cleanLines.add(trimmedLine);
-      }
-    }
-
-    // If the first line is empty, remove it
-    if (cleanLines.isNotEmpty && cleanLines.first.isEmpty) {
-      cleanLines.removeAt(0);
-    }
-    // If the last line is empty, remove it
-    if (cleanLines.isNotEmpty && cleanLines.last.isEmpty) {
-      cleanLines.removeLast();
-    }
-
-    // When there are 2 blank strings back to back, remove one of them
-    for (int i = 0; i < cleanLines.length - 1; i++) {
-      if (cleanLines[i].isEmpty && cleanLines[i + 1].isEmpty) {
-        cleanLines.removeAt(i);
-      }
-    }
-
-    _descriptionLines = cleanLines;
+    _descriptionLines =
+        MultiLineApexDocAnnotation.parse(descriptionLines).lines;
   }
 
   /// Gets the description as a single line.

--- a/lib/src/model/doc_comment.dart
+++ b/lib/src/model/doc_comment.dart
@@ -35,16 +35,12 @@ class DocComment {
 
   Map<String, dynamic> toJson() => _$DocCommentToJson(this);
 
-  List<String> get descriptionLines {
-    print('getting description lines ${_descriptionLines.length}');
-    print('with annotations ${annotations.map((e) => e.toJson())}');
-    return _descriptionLines.isNotEmpty
-        ? _descriptionLines
-        : annotations
-                .firstWhereOrNull((element) => element.name == 'description')
-                ?.bodyLines ??
-            [];
-  }
+  List<String> get descriptionLines => _descriptionLines.isNotEmpty
+      ? _descriptionLines
+      : annotations
+              .firstWhereOrNull((element) => element.name == 'description')
+              ?.bodyLines ??
+          [];
 
   set descriptionLines(List<String> descriptionLines) {
     List<String> cleanLines = [];
@@ -80,9 +76,8 @@ class DocComment {
   }
 
   /// Gets the description as a single line.
-  String get description => descriptionLines
-      .map((e) => e == '' ? '\n' : e)
-      .join('');
+  String get description =>
+      descriptionLines.map((e) => e == '' ? '\n' : e).join('');
 
   List<DocCommentAnnotation> annotationsByName(String annotationName) {
     return annotations

--- a/lib/src/model/doc_comment.dart
+++ b/lib/src/model/doc_comment.dart
@@ -49,8 +49,7 @@ class DocComment {
   }
 
   /// Gets the description as a single line.
-  String get description =>
-      descriptionLines.map((e) => e == '' ? '\n' : e).join('');
+  String get description => descriptionLines.asSingleLine;
 
   List<DocCommentAnnotation> annotationsByName(String annotationName) {
     return annotations
@@ -67,7 +66,7 @@ class DocCommentAnnotation {
 
   List<String> bodyLines = [];
 
-  String get body => bodyLines.map((e) => e.isEmpty ? '\n' : e).join('');
+  String get body => bodyLines.asSingleLine;
 
   DocCommentAnnotation(this.name, body) {
     if (body is String) {
@@ -141,4 +140,8 @@ class ExampleDocCommentAnnotation extends DocCommentAnnotation {
 
   @override
   Map<String, dynamic> toJson() => _$ExampleDocCommentAnnotationToJson(this);
+}
+
+extension on List<String> {
+  String get asSingleLine => map((e) => e.isEmpty ? '\n' : e).join('');
 }

--- a/lib/src/model/doc_sanitizer.dart
+++ b/lib/src/model/doc_sanitizer.dart
@@ -1,0 +1,10 @@
+String sanitizeLineStart(String line) {
+  var sanitizedLine = line.trimLeft();
+  if (sanitizedLine.startsWith('*')) {
+    sanitizedLine = sanitizedLine.replaceFirst('*', '');
+  }
+  if (sanitizedLine.startsWith(' ')) {
+    sanitizedLine = sanitizedLine.replaceFirst(' ', '');
+  }
+  return sanitizedLine.trimRight();
+}

--- a/lib/src/model/multi_line_apex_doc_annotation.dart
+++ b/lib/src/model/multi_line_apex_doc_annotation.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:apexdocs_dart/src/extension_methods/list_extensions.dart';
+
+import 'doc_sanitizer.dart';
+
+class MultiLineApexDocAnnotation {
+  final List<String> lines;
+
+  MultiLineApexDocAnnotation._(this.lines);
+
+  factory MultiLineApexDocAnnotation.parse(List<String> lines) {
+    return MultiLineApexDocAnnotation._(
+      lines
+          .expand(_split)
+          .map(sanitizeLineStart)
+          .withoutLeadingEmptyLines()
+          .withoutTrailingEmptyLines()
+          .withoutConsecutiveEmptyLines()
+          .toList(),
+    );
+  }
+
+  static List<String> _split(String line) {
+    return line.split('\n');
+  }
+}
+
+extension Sanitizer on Iterable<String> {
+  Iterable<String> withoutLeadingEmptyLines() {
+    return skipWhile((line) => line.isEmpty);
+  }
+
+  Iterable<String> withoutTrailingEmptyLines() {
+    return reversed.skipWhile((line) => line.isEmpty).reversed;
+  }
+
+  Iterable<String> withoutConsecutiveEmptyLines() {
+    return fold(<String>[], (List<String> acc, String line) {
+      if (acc.isNotEmpty && acc.last.isEmpty && line.isEmpty) {
+        return acc;
+      }
+      return [...acc, line];
+    }).cast();
+  }
+}

--- a/lib/src/model/multi_line_apex_doc_annotation.dart
+++ b/lib/src/model/multi_line_apex_doc_annotation.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:apexdocs_dart/src/extension_methods/list_extensions.dart';
 
 import 'doc_sanitizer.dart';

--- a/lib/src/node/node.dart
+++ b/lib/src/node/node.dart
@@ -22,5 +22,5 @@ String _parseFromDeclarationBody(String declarationBody) {
 
 void main() {
   exports.reflect = allowInterop(
-      (String declarationBody) => _parseFromDeclarationBody(declarationBody));
+          (String declarationBody) => _parseFromDeclarationBody(declarationBody));
 }

--- a/lib/src/service/apex_listener.dart
+++ b/lib/src/service/apex_listener.dart
@@ -145,8 +145,10 @@ class ApexClassListener extends ApexParserBaseListener {
       // We take and parse the first doc comment, in case it is the
       // start of a group.
       String potentialDocComment = allDocComments.first;
+      print('potentialDocComment: $potentialDocComment');
       DocComment docCommentObject =
           ApexdocParser.parseFromBody(potentialDocComment);
+      print('docCommentObject: ${docCommentObject.description}');
 
       if (docCommentObject.annotations
           .any((element) => element.name.toLowerCase() == 'start-group')) {

--- a/lib/src/service/apex_listener.dart
+++ b/lib/src/service/apex_listener.dart
@@ -145,10 +145,8 @@ class ApexClassListener extends ApexParserBaseListener {
       // We take and parse the first doc comment, in case it is the
       // start of a group.
       String potentialDocComment = allDocComments.first;
-      print('potentialDocComment: $potentialDocComment');
       DocComment docCommentObject =
           ApexdocParser.parseFromBody(potentialDocComment);
-      print('docCommentObject: ${docCommentObject.description}');
 
       if (docCommentObject.annotations
           .any((element) => element.name.toLowerCase() == 'start-group')) {

--- a/test/apex_listener_test.dart
+++ b/test/apex_listener_test.dart
@@ -58,7 +58,29 @@ void main() {
           equals('Continues here'));
     });
 
-    // TODO: Same test with @description
+    test('Empty lines in Apex docs are respected when using @description', () {
+      final apexWalkerDefinition = ApexWalkerDefinition();
+      const classBody = '''
+      /**
+       * @description Class description
+       *
+       * Continues here
+       */
+      class MyClass{}
+      ''';
+      Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
+          apexWalkerDefinition);
+      expect(apexWalkerDefinition.getGeneratedApexType()!.rawDocComment,
+          isNotNull);
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment?.descriptionLines.length,
+          equals(3));
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment!.descriptionLines.first,
+          equals('Class description'));
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment!.descriptionLines[1],
+          equals(''));
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment!.descriptionLines.last,
+          equals('Continues here'));
+    });
 
     test('Classes can have Apex block style docs', () {
       final apexWalkerDefinition = ApexWalkerDefinition();

--- a/test/apex_listener_test.dart
+++ b/test/apex_listener_test.dart
@@ -34,6 +34,32 @@ void main() {
           equals('Class description'));
     });
 
+    test('Empty lines in Apex docs are respected', () {
+      final apexWalkerDefinition = ApexWalkerDefinition();
+      const classBody = '''
+      /**
+       * Class description
+       *
+       * Continues here
+       */
+      class MyClass{}
+      ''';
+      Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
+          apexWalkerDefinition);
+      expect(apexWalkerDefinition.getGeneratedApexType()!.rawDocComment,
+          isNotNull);
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment?.descriptionLines.length,
+          equals(3));
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment!.descriptionLines.first,
+          equals('Class description'));
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment!.descriptionLines[1],
+          equals(''));
+      expect(apexWalkerDefinition.getGeneratedApexType()!.docComment!.descriptionLines.last,
+          equals('Continues here'));
+    });
+
+    // TODO: Same test with @description
+
     test('Classes can have Apex block style docs', () {
       final apexWalkerDefinition = ApexWalkerDefinition();
       const classBody = '''
@@ -188,7 +214,7 @@ void main() {
               'public virtual class MyClass{}'),
           apexWalkerDefinition);
       final generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.isVirtual, isTrue);
     });
 
@@ -199,7 +225,7 @@ void main() {
               'public abstract class MyClass{}'),
           apexWalkerDefinition);
       final generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.isAbstract, isTrue);
     });
 
@@ -268,7 +294,7 @@ void main() {
           CaseInsensitiveInputStream.fromString('public class MyClass{}'),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.extendedClass, isNull);
     });
 
@@ -279,7 +305,7 @@ void main() {
               'public class MyClass extends ParentClass{}'),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.extendedClass, equals('ParentClass'));
     });
 
@@ -294,7 +320,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.properties.length, equals(2));
       expect(
           generatedClass.properties
@@ -333,7 +359,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.properties.length, equals(1));
       expect(
           generatedClass.properties
@@ -356,7 +382,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(3));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -391,7 +417,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(1));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -413,7 +439,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(1));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -438,7 +464,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(3));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -560,8 +586,8 @@ void main() {
       final apexWalkerDefinition = ApexWalkerDefinition();
       var classBody = '''
       public class MyClass {
-        /** 
-         * @start-group Variables 
+        /**
+         * @start-group Variables
          * @description Group description
          */
         private String myVar1, myVar2;
@@ -648,7 +674,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(1));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -672,7 +698,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(3));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -713,7 +739,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(3));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -754,7 +780,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.fields.length, equals(1));
       expect(generatedClass.fields.any((element) => element.name == 'myVar1'),
           isTrue);
@@ -781,7 +807,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.methods.length, equals(2));
       expect(generatedClass.methods.any((element) => element.name == 'sayHi'),
           isTrue);
@@ -903,7 +929,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.methods.length, equals(1));
       expect(generatedClass.methods.any((element) => element.name == 'sayHi'),
           isTrue);
@@ -930,7 +956,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.methods.length, equals(1));
       expect(generatedClass.methods.any((element) => element.name == 'sayHi'),
           isTrue);
@@ -958,7 +984,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.methods.length, equals(1));
       expect(generatedClass.methods.any((element) => element.name == 'sayHi'),
           isTrue);
@@ -989,7 +1015,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.constructors.length, equals(2));
       expect(
           generatedClass.constructors
@@ -1029,7 +1055,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.constructors.length, equals(1));
       expect(
           generatedClass.constructors
@@ -1055,7 +1081,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.enums.length, equals(1));
       expect(generatedClass.enums.first.name, equals('MyEnum'));
       expect(generatedClass.enums.first.isNamespaceAccessible, isTrue);
@@ -1079,7 +1105,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.enums.length, equals(1));
       expect(generatedClass.enums.first.rawDocComment, isNotNull);
     });
@@ -1098,7 +1124,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.interfaces.length, equals(1));
 
       var innerInterface = generatedClass.interfaces.first;
@@ -1126,7 +1152,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.interfaces.length, equals(1));
 
       var innerInterface = generatedClass.interfaces.first;
@@ -1148,7 +1174,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.classes.length, equals(1));
 
       var innerClass = generatedClass.classes.first;
@@ -1178,7 +1204,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(classBody),
           apexWalkerDefinition);
       var generatedClass =
-          apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
+      apexWalkerDefinition.getGeneratedApexType() as ClassMirror;
       expect(generatedClass.classes.length, equals(1));
 
       var innerClass = generatedClass.classes.first;
@@ -1252,7 +1278,7 @@ void main() {
               'public interface MyInterface extends Interface1, Interface2{}'),
           apexWalkerDefinition);
       var generatedInterface =
-          apexWalkerDefinition.getGeneratedApexType() as InterfaceMirror;
+      apexWalkerDefinition.getGeneratedApexType() as InterfaceMirror;
       expect(generatedInterface.extendedInterfaces, isNotEmpty);
       expect(generatedInterface.extendedInterfaces[0], 'Interface1');
       expect(generatedInterface.extendedInterfaces[1], 'Interface2');
@@ -1271,7 +1297,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(interfaceBody),
           apexWalkerDefinition);
       var generatedInterface =
-          apexWalkerDefinition.getGeneratedApexType() as InterfaceMirror;
+      apexWalkerDefinition.getGeneratedApexType() as InterfaceMirror;
       expect(generatedInterface.methods.length, equals(2));
       expect(
           generatedInterface.methods.any((element) => element.name == 'sayHi'),
@@ -1311,7 +1337,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(interfaceBody),
           apexWalkerDefinition);
       var generatedInterface =
-          apexWalkerDefinition.getGeneratedApexType() as InterfaceMirror;
+      apexWalkerDefinition.getGeneratedApexType() as InterfaceMirror;
       expect(generatedInterface.methods.length, equals(1));
       expect(
           generatedInterface.methods.any((element) => element.name == 'sayHi'),
@@ -1426,7 +1452,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(enumBody),
           apexWalkerDefinition);
       var generatedEnum =
-          apexWalkerDefinition.getGeneratedApexType() as EnumMirror;
+      apexWalkerDefinition.getGeneratedApexType() as EnumMirror;
       expect(generatedEnum.values.length, equals(3));
       expect(generatedEnum.values.any((element) => element.name == 'VALUE1'),
           isTrue);
@@ -1436,7 +1462,6 @@ void main() {
           isTrue);
     });
 
-    // enum values can have descriptions
     test('enum values can have descriptions', () {
       final apexWalkerDefinition = ApexWalkerDefinition();
       var enumBody = '''
@@ -1453,7 +1478,7 @@ void main() {
       Walker.walk(CaseInsensitiveInputStream.fromString(enumBody),
           apexWalkerDefinition);
       var generatedEnum =
-          apexWalkerDefinition.getGeneratedApexType() as EnumMirror;
+      apexWalkerDefinition.getGeneratedApexType() as EnumMirror;
       expect(generatedEnum.values.length, equals(3));
       expect(generatedEnum.values.any((element) => element.name == 'VALUE1'),
           isTrue);

--- a/test/apexdoc_parser_test.dart
+++ b/test/apexdoc_parser_test.dart
@@ -204,6 +204,24 @@ main() {
         equals("String testString = 'MyString';"));
   });
 
+  test('Can parse an example tag with multiple lines and breaks', () {
+    final docBody = '''
+    /**
+      * @description This is a description.
+      * @example
+      * String testString = 'MyString';
+      *
+      * System.debug(testString);
+      */
+    ''';
+    final docComment = ApexdocParser.parseFromBody(docBody);
+    expect(docComment.exampleAnnotation, isNotNull);
+    expect(docComment.exampleAnnotation!.bodyLines.length, equals(3));
+    print(docComment.exampleAnnotation!.bodyLines);
+    expect(docComment.exampleAnnotation!.body,
+        equals("String testString = 'MyString';\nSystem.debug(testString);"));
+  });
+
   test('Can parse custom tags', () {
     final docBody = '''
     /**

--- a/test/apexdoc_parser_test.dart
+++ b/test/apexdoc_parser_test.dart
@@ -40,7 +40,7 @@ main() {
     ''';
     final docComment = ApexdocParser.parseFromBody(docBody);
     expect(docComment.description,
-        'This is a description. The description continues here.');
+        'This is a description.\nThe description continues here.');
   });
 
   test('Can parse tagged description', () {
@@ -102,9 +102,9 @@ main() {
       */
     ''';
     final docComment = ApexdocParser.parseFromBody(docBody);
-    expect(docComment.descriptionLines.length, equals(2));
+    expect(docComment.descriptionLines.length, equals(3));
     expect(docComment.description,
-        equals('This is a description. The description continues here'));
+        equals('This is a description.\nThe description continues here'));
   });
 
   test('Can parse a tag', () {
@@ -148,7 +148,7 @@ main() {
     expect(docComment.paramAnnotations.length, equals(1));
     expect(docComment.paramAnnotations.first.paramName, equals('param1'));
     expect(docComment.paramAnnotations.first.body,
-        equals('description1 The description continues here.'));
+        equals('description1\nThe description continues here.'));
   });
 
   test('Can parse a return tag', () {

--- a/test/model/multi_line_apex_doc_annotation_test.dart
+++ b/test/model/multi_line_apex_doc_annotation_test.dart
@@ -1,0 +1,52 @@
+import 'package:apexdocs_dart/src/model/multi_line_apex_doc_annotation.dart';
+import 'package:test/test.dart';
+
+main() {
+  test('returns the same list of strings when there is nothing to sanitize', () {
+    final descriptionLines = ['line 1', 'line 2', 'line 3'];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, descriptionLines);
+  });
+
+  test('sanitizes line starts', () {
+    final descriptionLines = ['line 1', '* line 2', 'line 3'];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', 'line 2', 'line 3']);
+  });
+
+  test('breaks up lines with newlines', () {
+    final descriptionLines = ['line 1', 'line 2\nline3', 'line 4'];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', 'line 2', 'line3', 'line 4']);
+  });
+
+  test('trims leading and trailing whitespace', () {
+    final descriptionLines = ['  line 1  ', '  line 2  ', '  line 3  '];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', 'line 2', 'line 3']);
+  });
+
+  test('remove all leading empty lines', () {
+    final descriptionLines = ['', '', 'line 1', 'line 2', 'line 3'];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', 'line 2', 'line 3']);
+  });
+
+  test('keeps empty lines in the middle', () {
+    final descriptionLines = ['line 1', '', 'line 2', '', 'line 3'];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', '', 'line 2', '', 'line 3']);
+  });
+
+  test('removes all trailing empty lines', () {
+    final descriptionLines = ['line 1', 'line 2', 'line 3', '', ''];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', 'line 2', 'line 3']);
+  });
+
+  test('removes consecutive empty lines', () {
+    final descriptionLines = ['line 1', '', '', 'line 2', '', '', 'line 3'];
+    final multiLine = MultiLineApexDocAnnotation.parse(descriptionLines);
+    expect(multiLine.lines, ['line 1', '', 'line 2', '', 'line 3']);
+  });
+}


### PR DESCRIPTION
This PR improves the way annotations with multi-line bodies are handled.

Before, empty lines where completely ignored, and the annotation's body and bodyLines were returned without them. But empty lines might actually be important, since they can denote an intentional break in how things are presented.

Some examples:
* when dealing with a long description, empty lines might denote paragraphs.
* when dealing with example code, empty lines might denote code separation